### PR TITLE
Removed old country codes for Kosovo

### DIFF
--- a/lib/src/res/country_codes.dart
+++ b/lib/src/res/country_codes.dart
@@ -1534,32 +1534,6 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "383-XK-0"
   },
   {
-    "e164_cc": "381",
-    "iso2_cc": "XK",
-    "e164_sc": 0,
-    "geographic": true,
-    "level": 2,
-    "name": "Kosovo",
-    "example": "",
-    "display_name": "Kosovo (XK) [+381]",
-    "full_example_with_plus_sign": null,
-    "display_name_no_e164_cc": "Kosovo (XK)",
-    "e164_key": "381-XK-0"
-  },
-  {
-    "e164_cc": "386",
-    "iso2_cc": "XK",
-    "e164_sc": 0,
-    "geographic": true,
-    "level": 2,
-    "name": "Kosovo",
-    "example": "",
-    "display_name": "Kosovo (XK) [+386]",
-    "full_example_with_plus_sign": null,
-    "display_name_no_e164_cc": "Kosovo (XK)",
-    "e164_key": "386-XK-0"
-  },
-  {
     "e164_cc": "965",
     "iso2_cc": "KW",
     "e164_sc": 0,


### PR DESCRIPTION
+381 & +386 has been removed after +383 has been introduced. Removes confusion.