### PR TITLE
UI filling fix

### DIFF
--- a/lib/country_picker.dart
+++ b/lib/country_picker.dart
@@ -55,8 +55,6 @@ void showCountryPicker({
   bool showWorldWide = false,
   bool showSearch = true,
   bool useSafeArea = false,
-  EdgeInsets? padding,
-  EdgeInsets? margin,
 }) {
   assert(
     exclude == null || countryFilter == null,
@@ -75,7 +73,5 @@ void showCountryPicker({
     showWorldWide: showWorldWide,
     showSearch: showSearch,
     useSafeArea: useSafeArea,
-    padding: padding,
-    margin: margin,
   );
 }

--- a/lib/country_picker.dart
+++ b/lib/country_picker.dart
@@ -54,6 +54,7 @@ void showCountryPicker({
   bool searchAutofocus = false,
   bool showWorldWide = false,
   bool showSearch = true,
+  bool useSafeArea = false,
 }) {
   assert(
     exclude == null || countryFilter == null,
@@ -71,5 +72,6 @@ void showCountryPicker({
     searchAutofocus: searchAutofocus,
     showWorldWide: showWorldWide,
     showSearch: showSearch,
+    useSafeArea: useSafeArea,
   );
 }

--- a/lib/country_picker.dart
+++ b/lib/country_picker.dart
@@ -55,6 +55,8 @@ void showCountryPicker({
   bool showWorldWide = false,
   bool showSearch = true,
   bool useSafeArea = false,
+  EdgeInsets? padding,
+  EdgeInsets? margin,
 }) {
   assert(
     exclude == null || countryFilter == null,
@@ -73,5 +75,7 @@ void showCountryPicker({
     showWorldWide: showWorldWide,
     showSearch: showSearch,
     useSafeArea: useSafeArea,
+    padding: padding,
+    margin: margin,
   );
 }

--- a/lib/src/country_list_bottom_sheet.dart
+++ b/lib/src/country_list_bottom_sheet.dart
@@ -17,6 +17,8 @@ void showCountryListBottomSheet({
   bool showWorldWide = false,
   bool showSearch = true,
   bool useSafeArea = false,
+  EdgeInsets? padding,
+  EdgeInsets? margin,
 }) {
   showModalBottomSheet(
     context: context,
@@ -34,6 +36,8 @@ void showCountryListBottomSheet({
       searchAutofocus,
       showWorldWide,
       showSearch,
+      padding,
+      margin,
     ),
   ).whenComplete(() {
     if (onClosed != null) onClosed();
@@ -51,6 +55,8 @@ Widget _builder(
   bool searchAutofocus,
   bool showWorldWide,
   bool showSearch,
+  EdgeInsets? padding,
+  EdgeInsets? margin,
 ) {
   final device = MediaQuery.of(context).size.height;
   final statusBarHeight = MediaQuery.of(context).padding.top;
@@ -75,6 +81,8 @@ Widget _builder(
 
   return Container(
     height: height,
+    padding: padding,
+    margin: margin,
     decoration: BoxDecoration(
       color: _backgroundColor,
       borderRadius: _borderRadius,

--- a/lib/src/country_list_bottom_sheet.dart
+++ b/lib/src/country_list_bottom_sheet.dart
@@ -16,11 +16,13 @@ void showCountryListBottomSheet({
   bool searchAutofocus = false,
   bool showWorldWide = false,
   bool showSearch = true,
+  bool useSafeArea = false,
 }) {
   showModalBottomSheet(
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
+    useSafeArea: useSafeArea,
     builder: (context) => _builder(
       context,
       onSelect,

--- a/lib/src/country_list_bottom_sheet.dart
+++ b/lib/src/country_list_bottom_sheet.dart
@@ -17,8 +17,6 @@ void showCountryListBottomSheet({
   bool showWorldWide = false,
   bool showSearch = true,
   bool useSafeArea = false,
-  EdgeInsets? padding,
-  EdgeInsets? margin,
 }) {
   showModalBottomSheet(
     context: context,
@@ -36,8 +34,6 @@ void showCountryListBottomSheet({
       searchAutofocus,
       showWorldWide,
       showSearch,
-      padding,
-      margin,
     ),
   ).whenComplete(() {
     if (onClosed != null) onClosed();
@@ -55,8 +51,6 @@ Widget _builder(
   bool searchAutofocus,
   bool showWorldWide,
   bool showSearch,
-  EdgeInsets? padding,
-  EdgeInsets? margin,
 ) {
   final device = MediaQuery.of(context).size.height;
   final statusBarHeight = MediaQuery.of(context).padding.top;
@@ -81,8 +75,8 @@ Widget _builder(
 
   return Container(
     height: height,
-    padding: padding,
-    margin: margin,
+    padding: countryListTheme?.padding,
+    margin: countryListTheme?.margin,
     decoration: BoxDecoration(
       color: _backgroundColor,
       borderRadius: _borderRadius,

--- a/lib/src/country_list_theme_data.dart
+++ b/lib/src/country_list_theme_data.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 class CountryListThemeData {
   /// The country bottom sheet's background color.
@@ -36,6 +37,12 @@ class CountryListThemeData {
   /// By default it's fullscreen
   final double? bottomSheetHeight;
 
+  /// the padding of the bottom sheet
+  final EdgeInsets? padding;
+
+  /// the margin of the bottom sheet
+  final EdgeInsets? margin;
+
   const CountryListThemeData({
     this.backgroundColor,
     this.textStyle,
@@ -44,5 +51,7 @@ class CountryListThemeData {
     this.inputDecoration,
     this.borderRadius,
     this.bottomSheetHeight,
+    this.padding,
+    this.margin,
   });
 }


### PR DESCRIPTION
I was having a problem where the picker was filling the screen:

![Screenshot_1675369074](https://user-images.githubusercontent.com/54329101/216440486-22f2e450-fc98-4434-9b7a-5ac9d9baaa4a.png)


after using `useSafeArea` as `true` and adding a `top margin` of `10`, my problem was fixed
![Screenshot_1675369366](https://user-images.githubusercontent.com/54329101/216441408-69d71f8f-0bc8-4aec-a729-69ff0cc78ae2.png)


