### PR TITLE
feat(navigator): add field `useRootNavigator`

### DIFF
--- a/lib/country_picker.dart
+++ b/lib/country_picker.dart
@@ -55,6 +55,7 @@ void showCountryPicker({
   bool showWorldWide = false,
   bool showSearch = true,
   bool useSafeArea = false,
+  bool useRootNavigator = false,
 }) {
   assert(
     exclude == null || countryFilter == null,
@@ -73,5 +74,6 @@ void showCountryPicker({
     showWorldWide: showWorldWide,
     showSearch: showSearch,
     useSafeArea: useSafeArea,
+    useRootNavigator: useRootNavigator,
   );
 }

--- a/lib/src/country_list_bottom_sheet.dart
+++ b/lib/src/country_list_bottom_sheet.dart
@@ -17,8 +17,10 @@ void showCountryListBottomSheet({
   bool showWorldWide = false,
   bool showSearch = true,
   bool useSafeArea = false,
+  bool useRootNavigator = false,
 }) {
   showModalBottomSheet(
+    useRootNavigator: useRootNavigator,
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,


### PR DESCRIPTION
I passed down the field `useRootNavigator` so that when we can avoid the bottom sheet from being shown on top of some internal navigators in the cases that we need it. 