### PR TITLE
Move bottomsheet along with keyboard feature is aded.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -74,8 +74,11 @@ class HomePage extends StatelessWidget {
               onSelect: (Country country) {
                 print('Select country: ${country.displayName}');
               },
+              // Optional. Sheet moves when keyboard opens.
+              moveAlongWithKeyboard: true,
               // Optional. Sets the theme for the country list picker.
               countryListTheme: CountryListThemeData(
+                bottomSheetHeight: 300,
                 // Optional. Sets the border radius for the bottomsheet.
                 borderRadius: BorderRadius.only(
                   topLeft: Radius.circular(40.0),

--- a/lib/country_picker.dart
+++ b/lib/country_picker.dart
@@ -44,6 +44,12 @@ export 'src/country_service.dart';
 /// The `context` argument is used to look up the [Scaffold] for the bottom
 /// sheet. It is only used when the method is called. Its corresponding widget
 /// can be safely removed from the tree before the bottom sheet is closed.
+///
+/// An optional [moveAlongWithKeyboard] argument can be used to move bottomSheet
+/// along with keyboard when textfield is focused. It could be useful when
+/// bottomSheet height is smaller than half of the screen. Otherwise it
+/// shouldn't be set. It has a default value of false.
+
 void showCountryPicker({
   required BuildContext context,
   required ValueChanged<Country> onSelect,
@@ -59,6 +65,7 @@ void showCountryPicker({
   bool showSearch = true,
   bool useSafeArea = false,
   bool useRootNavigator = false,
+  bool moveAlongWithKeyboard = false,
 }) {
   assert(
     exclude == null || countryFilter == null,
@@ -79,5 +86,6 @@ void showCountryPicker({
     showSearch: showSearch,
     useSafeArea: useSafeArea,
     useRootNavigator: useRootNavigator,
+    moveAlongWithKeyboard: moveAlongWithKeyboard,
   );
 }

--- a/lib/src/country_list_bottom_sheet.dart
+++ b/lib/src/country_list_bottom_sheet.dart
@@ -19,6 +19,7 @@ void showCountryListBottomSheet({
   bool showSearch = true,
   bool useSafeArea = false,
   bool useRootNavigator = false,
+  bool moveAlongWithKeyboard = false,
 }) {
   showModalBottomSheet(
     context: context,
@@ -37,6 +38,7 @@ void showCountryListBottomSheet({
       searchAutofocus,
       showWorldWide,
       showSearch,
+      moveAlongWithKeyboard,
       customFlagBuilder,
     ),
   ).whenComplete(() {
@@ -55,6 +57,7 @@ Widget _builder(
   bool searchAutofocus,
   bool showWorldWide,
   bool showSearch,
+  bool moveAlongWithKeyboard,
   CustomFlagBuilder? customFlagBuilder,
 ) {
   final device = MediaQuery.of(context).size.height;
@@ -78,26 +81,29 @@ Widget _builder(
         topRight: Radius.circular(40.0),
       );
 
-  return Container(
-    height: height,
-    width: width,
-    padding: countryListTheme?.padding,
-    margin: countryListTheme?.margin,
-    decoration: BoxDecoration(
-      color: _backgroundColor,
-      borderRadius: _borderRadius,
-    ),
-    child: CountryListView(
-      onSelect: onSelect,
-      exclude: exclude,
-      favorite: favorite,
-      countryFilter: countryFilter,
-      showPhoneCode: showPhoneCode,
-      countryListTheme: countryListTheme,
-      searchAutofocus: searchAutofocus,
-      showWorldWide: showWorldWide,
-      showSearch: showSearch,
-      customFlagBuilder: customFlagBuilder,
+  return Padding(
+    padding: moveAlongWithKeyboard ? MediaQuery.of(context).viewInsets : EdgeInsets.zero,
+    child: Container(
+      height: height,
+      width: width,
+      padding: countryListTheme?.padding,
+      margin: countryListTheme?.margin,
+      decoration: BoxDecoration(
+        color: _backgroundColor,
+        borderRadius: _borderRadius,
+      ),
+      child: CountryListView(
+        onSelect: onSelect,
+        exclude: exclude,
+        favorite: favorite,
+        countryFilter: countryFilter,
+        showPhoneCode: showPhoneCode,
+        countryListTheme: countryListTheme,
+        searchAutofocus: searchAutofocus,
+        showWorldWide: showWorldWide,
+        showSearch: showSearch,
+        customFlagBuilder: customFlagBuilder,
+      ),
     ),
   );
 }


### PR DESCRIPTION
This pr adds capability of moving bottomSheet along with keyboard when search bar is focued.

bottomSheet height is customizable. When it is set to a value which is smaller than half of the screen, it gets harder to see search results because of the keyboard. By setting only 'moveAlongWithKeyboard' to true, it is possible to move bottomSheet along with the keyboard.

It has a default value of false. It should only use with low 'bottomSheetHeight' values.

https://github.com/Daniel-Ioannou/flutter_country_picker/assets/34956737/4930fb12-34d6-4523-a93a-e455ae5b1284


