### PR TITLE
Add list header widget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -106,6 +106,16 @@ class HomePage extends StatelessWidget {
                   fontSize: 18,
                 ),
               ),
+              header: Padding(
+                padding: const EdgeInsets.only(top: 10.0, bottom: 10.0, left: 20.0, right: 20.0),
+                child: const Text(
+                  'Select your country',
+                  style: TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
             );
           },
           child: const Text('Show country picker'),

--- a/lib/country_picker.dart
+++ b/lib/country_picker.dart
@@ -66,6 +66,7 @@ void showCountryPicker({
   bool useSafeArea = false,
   bool useRootNavigator = false,
   bool moveAlongWithKeyboard = false,
+  Widget header = const SizedBox.shrink(),
 }) {
   assert(
     exclude == null || countryFilter == null,
@@ -87,5 +88,6 @@ void showCountryPicker({
     useSafeArea: useSafeArea,
     useRootNavigator: useRootNavigator,
     moveAlongWithKeyboard: moveAlongWithKeyboard,
+    header: header,
   );
 }

--- a/lib/src/country_list_bottom_sheet.dart
+++ b/lib/src/country_list_bottom_sheet.dart
@@ -20,6 +20,7 @@ void showCountryListBottomSheet({
   bool useSafeArea = false,
   bool useRootNavigator = false,
   bool moveAlongWithKeyboard = false,
+  Widget header = const SizedBox.shrink(),
 }) {
   showModalBottomSheet(
     context: context,
@@ -27,20 +28,8 @@ void showCountryListBottomSheet({
     backgroundColor: Colors.transparent,
     useSafeArea: useSafeArea,
     useRootNavigator: useRootNavigator,
-    builder: (context) => _builder(
-      context,
-      onSelect,
-      favorite,
-      exclude,
-      countryFilter,
-      showPhoneCode,
-      countryListTheme,
-      searchAutofocus,
-      showWorldWide,
-      showSearch,
-      moveAlongWithKeyboard,
-      customFlagBuilder,
-    ),
+    builder: (context) => _builder(context, onSelect, favorite, exclude, countryFilter, showPhoneCode, countryListTheme,
+        searchAutofocus, showWorldWide, showSearch, moveAlongWithKeyboard, customFlagBuilder, header),
   ).whenComplete(() {
     if (onClosed != null) onClosed();
   });
@@ -59,6 +48,7 @@ Widget _builder(
   bool showSearch,
   bool moveAlongWithKeyboard,
   CustomFlagBuilder? customFlagBuilder,
+  Widget header,
 ) {
   final device = MediaQuery.of(context).size.height;
   final statusBarHeight = MediaQuery.of(context).padding.top;
@@ -92,17 +82,27 @@ Widget _builder(
         color: _backgroundColor,
         borderRadius: _borderRadius,
       ),
-      child: CountryListView(
-        onSelect: onSelect,
-        exclude: exclude,
-        favorite: favorite,
-        countryFilter: countryFilter,
-        showPhoneCode: showPhoneCode,
-        countryListTheme: countryListTheme,
-        searchAutofocus: searchAutofocus,
-        showWorldWide: showWorldWide,
-        showSearch: showSearch,
-        customFlagBuilder: customFlagBuilder,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        child: Column(
+          children: [
+            header,
+            Flexible(
+              child: CountryListView(
+                onSelect: onSelect,
+                exclude: exclude,
+                favorite: favorite,
+                countryFilter: countryFilter,
+                showPhoneCode: showPhoneCode,
+                countryListTheme: countryListTheme,
+                searchAutofocus: searchAutofocus,
+                showWorldWide: showWorldWide,
+                showSearch: showSearch,
+                customFlagBuilder: customFlagBuilder,
+              ),
+            ),
+          ],
+        ),
       ),
     ),
   );

--- a/lib/src/country_list_view.dart
+++ b/lib/src/country_list_view.dart
@@ -130,26 +130,23 @@ class _CountryListViewState extends State<CountryListView> {
       children: <Widget>[
         const SizedBox(height: 12),
         if (widget.showSearch)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-            child: TextField(
-              autofocus: _searchAutofocus,
-              controller: _searchController,
-              style:
-              widget.countryListTheme?.searchTextStyle ?? _defaultTextStyle,
-              decoration: widget.countryListTheme?.inputDecoration ??
-                  InputDecoration(
-                    labelText: searchLabel,
-                    hintText: searchLabel,
-                    prefixIcon: const Icon(Icons.search),
-                    border: OutlineInputBorder(
-                      borderSide: BorderSide(
-                        color: const Color(0xFF8C98A8).withOpacity(0.2),
-                      ),
+          TextField(
+            autofocus: _searchAutofocus,
+            controller: _searchController,
+            style:
+            widget.countryListTheme?.searchTextStyle ?? _defaultTextStyle,
+            decoration: widget.countryListTheme?.inputDecoration ??
+                InputDecoration(
+                  labelText: searchLabel,
+                  hintText: searchLabel,
+                  prefixIcon: const Icon(Icons.search),
+                  border: OutlineInputBorder(
+                    borderSide: BorderSide(
+                      color: const Color(0xFF8C98A8).withOpacity(0.2),
                     ),
                   ),
-              onChanged: _filterSearchResults,
-            ),
+                ),
+            onChanged: _filterSearchResults,
           ),
         Expanded(
           child: ListView(


### PR DESCRIPTION
it adds the option to include a custom list header inside the modal.
I had a few projects that I needed this feature and it's very simple, so I think it might be a good addition to the repo.

I moved up the padding widget so it is easier to control spacing between the modal, the header and the list.
I will attach two screenshots of the result: one with header and other without it.

<p float="left">
<img src="https://github.com/user-attachments/assets/fbc8106c-84d2-4114-a6af-69817a27e5c2" height="600">
<img src="https://github.com/user-attachments/assets/0ec36a8d-65da-4974-bbd5-b6901152a5f2" height="600">
</p>
