### PR TITLE
Fix issue when pass 1 in .parsePhoneCode('1') method

### DIFF
--- a/lib/src/country_parser.dart
+++ b/lib/src/country_parser.dart
@@ -136,8 +136,8 @@ class CountryParser {
   /// Returns a country that matches the [countryCode] (e164_cc).
   static Country _getFromPhoneCode(String phoneCode) {
     return Country.from(
-      json:  countryCodes.firstWhere(
-            (Map<String, dynamic> c) => c['e164_cc'] == phoneCode,
+      json: countryCodes.firstWhere(
+        (Map<String, dynamic> c) => c['e164_cc'] == phoneCode,
       ),
     );
   }

--- a/lib/src/country_parser.dart
+++ b/lib/src/country_parser.dart
@@ -136,7 +136,7 @@ class CountryParser {
   /// Returns a country that matches the [countryCode] (e164_cc).
   static Country _getFromPhoneCode(String phoneCode) {
     return Country.from(
-     countryCodes.firstWhere(
+      json:  countryCodes.firstWhere(
             (Map<String, dynamic> c) => c['e164_cc'] == phoneCode,
       ),
     );

--- a/lib/src/country_parser.dart
+++ b/lib/src/country_parser.dart
@@ -136,8 +136,8 @@ class CountryParser {
   /// Returns a country that matches the [countryCode] (e164_cc).
   static Country _getFromPhoneCode(String phoneCode) {
     return Country.from(
-      json: countryCodes.singleWhere(
-        (Map<String, dynamic> c) => c['e164_cc'] == phoneCode,
+     countryCodes.firstWhere(
+            (Map<String, dynamic> c) => c['e164_cc'] == phoneCode,
       ),
     );
   }


### PR DESCRIPTION
when you pass 1 in CountryParser.parsePhoneCode('1') that time multiple country have 1 as phone code so i do modification in below condition  with singleWhere to fistWhere.

 static Country _getFromPhoneCode(String phoneCode) {
    return Country.from(
      json: countryCodes.firstWhere(
        (Map<String, dynamic> c) => c['e164_cc'] == phoneCode,
      ),
    );
  }