### PR TITLE
update incomplete prefix number

### DIFF
--- a/lib/src/res/country_codes.dart
+++ b/lib/src/res/country_codes.dart
@@ -52,7 +52,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "213-DZ-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1684",
     "iso2_cc": "AS",
     "e164_sc": 0,
     "geographic": true,
@@ -91,7 +91,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "244-AO-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1264",
     "iso2_cc": "AI",
     "e164_sc": 0,
     "geographic": true,
@@ -104,7 +104,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "1-AI-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1268",
     "iso2_cc": "AG",
     "e164_sc": 0,
     "geographic": true,
@@ -208,7 +208,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "994-AZ-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1242",
     "iso2_cc": "BS",
     "e164_sc": 0,
     "geographic": true,
@@ -247,7 +247,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "880-BD-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1246",
     "iso2_cc": "BB",
     "e164_sc": 0,
     "geographic": true,
@@ -312,7 +312,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "229-BJ-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1441",
     "iso2_cc": "BM",
     "e164_sc": 0,
     "geographic": true,
@@ -403,7 +403,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "246-IO-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1284",
     "iso2_cc": "VG",
     "e164_sc": 0,
     "geographic": true,
@@ -533,7 +533,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "599-BQ-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1345",
     "iso2_cc": "KY",
     "e164_sc": 0,
     "geographic": true,
@@ -806,7 +806,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "253-DJ-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1767",
     "iso2_cc": "DM",
     "e164_sc": 0,
     "geographic": true,
@@ -819,7 +819,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "1-DM-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1809",
     "iso2_cc": "DO",
     "e164_sc": 0,
     "geographic": true,
@@ -1144,7 +1144,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "299-GL-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1473",
     "iso2_cc": "GD",
     "e164_sc": 0,
     "geographic": true,
@@ -1170,7 +1170,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "590-GP-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1671",
     "iso2_cc": "GU",
     "e164_sc": 0,
     "geographic": true,
@@ -1430,7 +1430,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "39-IT-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1876",
     "iso2_cc": "JM",
     "e164_sc": 0,
     "geographic": true,
@@ -1924,7 +1924,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "382-ME-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1664",
     "iso2_cc": "MS",
     "e164_sc": 0,
     "geographic": true,
@@ -2301,7 +2301,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "351-PT-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1787",
     "iso2_cc": "PR",
     "e164_sc": 0,
     "geographic": true,
@@ -2405,7 +2405,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "290-SH-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1869",
     "iso2_cc": "KN",
     "e164_sc": 0,
     "geographic": true,
@@ -2418,7 +2418,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "1-KN-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1758",
     "iso2_cc": "LC",
     "e164_sc": 0,
     "geographic": true,
@@ -2457,7 +2457,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "508-PM-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1784",
     "iso2_cc": "VC",
     "e164_sc": 0,
     "geographic": true,
@@ -2587,7 +2587,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "65-SG-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1721",
     "iso2_cc": "SX",
     "e164_sc": 0,
     "geographic": true,
@@ -2900,7 +2900,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "676-TO-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1868",
     "iso2_cc": "TT",
     "e164_sc": 0,
     "geographic": true,
@@ -2952,7 +2952,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "993-TM-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1649",
     "iso2_cc": "TC",
     "e164_sc": 0,
     "geographic": true,
@@ -2978,7 +2978,7 @@ final List<Map<String, dynamic>> countryCodes = [
     "e164_key": "688-TV-0",
   },
   {
-    "e164_cc": "1",
+    "e164_cc": "1340",
     "iso2_cc": "VI",
     "e164_sc": 0,
     "geographic": true,


### PR DESCRIPTION
Update incorrect prefix number for the country that has leading prefix as "1"

| Country | Alphabet 2 | Prefix number should be |
|---------|------------|-------------------------|
|American Samoa | AS | 1684 |
|Anguilla | AI | 1264 |
|Antigua and Barbuda | AG | 1268 |
|Bahamas | BS | 1242 |
|Barbados | BB | 1246 |
|Bermuda | BM | 1441 |
|Virgin Islands, British | VG | 1340 |
|Cayman Islands | KY | 1345 |
|Dominica | DM | 1767 |
|Dominican Republic | DO | 1809 |
|Grenada | GD | 1473 |
|Guam | GU | 1671 |
|Jamaica | JM | 1876 |
|Montserrat | MS | 1664 |
|Puerto Rico | PR | 1787 |
|Saint Kitts and Nevis | KN | 1869 |
|Saint Lucia | LC | 1758 |
|Saint Vincent and The Grenadines | VC | 1784 |
|Sint Maarten (Dutch Part) | SX | 1721 |
|Trinidad and Tobago | TT | 1868 |
|Turks and Caicos Islands | TC | 1649 |
|Virgin Islands, US | VI | 1284 |
